### PR TITLE
Wait after correct

### DIFF
--- a/Assets/_CountryShooter/GameController/GameController.cs
+++ b/Assets/_CountryShooter/GameController/GameController.cs
@@ -91,16 +91,21 @@ public class GameController : MonoBehaviour
   {
     if (answer == currentCountryID)
     {
-      Debug.Log("Correct!");
-      currentCountryIndex++;
-      SetQuestion();
+      StartCoroutine(CorrectAnswer());
       return true;
     }
 
     Debug.Log("Incorrect.");
     incorrectAnswers++;
     return false;
+  }
 
+  private IEnumerator CorrectAnswer()
+  {
+    Debug.Log("Correct!");
+    yield return new WaitForSeconds(0.5f);
+    currentCountryIndex++;
+    SetQuestion();
   }
 
   public void EndGame()


### PR DESCRIPTION
When you got the right answer before, it instantly moved to the next country. There wasn't quite enough feedback to even know that you got it right. Now it waits .5 seconds just so it's clear, then moves on. 