### PR TITLE
Add Game Over Screen (Unstyled)

### DIFF
--- a/Assets/_CountryShooter/GameController/GameController.cs
+++ b/Assets/_CountryShooter/GameController/GameController.cs
@@ -40,6 +40,8 @@ public class GameController : MonoBehaviour
 
   void Awake()
   {
+    instructionText.text = "";
+
     MenuRegion.OnMenuClicked += StartGame;
     Country.OnCountryHit += CheckAnswer;
 

--- a/Assets/_CountryShooter/MainMenu/GameOverPanel.cs
+++ b/Assets/_CountryShooter/MainMenu/GameOverPanel.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+public class GameOverPanel : MonoBehaviour
+{
+  public string[] difficultyTranslations;
+
+  public TextMeshPro titleText;
+  public TextMeshPro difficultyText;
+  public TextMeshPro regionText;
+  public TextMeshPro scoreText;
+
+  void Start()
+  {
+    ClearGameOverMenu();
+  }
+
+  void ClearGameOverMenu()
+  {
+    titleText.text = "";
+    difficultyText.text = "";
+    regionText.text = "";
+    scoreText.text = "";
+  }
+
+  public void GameOver(int score, Constants.Region region, int difficulty)
+  {
+    titleText.text = "Game Over";
+    difficultyText.text = "Difficulty: " + difficultyTranslations[difficulty];
+    regionText.text = "Region: " + region;
+    scoreText.text = "Score: " + score;
+  }
+}

--- a/Assets/_CountryShooter/MainMenu/GameOverPanel.cs.meta
+++ b/Assets/_CountryShooter/MainMenu/GameOverPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b67f56cc06e2f45dab686f770e540070
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CountryShooter/Player/Scoreboard.cs
+++ b/Assets/_CountryShooter/Player/Scoreboard.cs
@@ -11,6 +11,7 @@ public class Scoreboard : MonoBehaviour
   public int incorrectPenalty;
 
   public TextMeshPro scoreText;
+  public GameOverPanel gameOverPanelScript;
 
   private int difficulty;
   private int score;
@@ -56,7 +57,7 @@ public class Scoreboard : MonoBehaviour
 
   private void gameOver()
   {
-    // save the final score
+    gameOverPanelScript.GameOver(score, region, difficulty);
   }
 
   private void correctAnswer()


### PR DESCRIPTION
Adds a basic game over screen that includes a title, the region, the difficulty and the score. 

<img width="952" alt="Screen Shot 2019-08-24 at 9 54 18 PM" src="https://user-images.githubusercontent.com/3202211/63645763-2f391e80-c6ba-11e9-8dd7-b21c7dd5a0f7.png">
